### PR TITLE
Run metric workflow conditionally in workflow

### DIFF
--- a/bolt-api/apps/bolt_api/app/workflow/argo.py
+++ b/bolt-api/apps/bolt_api/app/workflow/argo.py
@@ -340,25 +340,25 @@ class Argo:
                     "resources": self.CONTAINER_RESOURCES["worker"],
                 },
             }
-
-            template_load_tests_metric_watcher = {
-                "name": "load-tests-metric-watcher",
-                "nodeSelector": {"group": "load-tests-metric-watcher"},
-                "container": {
-                    "image": "{{workflow.outputs.parameters.image}}",
-                    "command": ["python", "-m", "monitoring"],
-                    "env": [
-                        *self._map_envs(workflow.job_metric_watcher.env_vars),
-                        {"name": "EXECUTION_ID", "value": workflow.execution_id},
-                        {"name": "BOLT_GRAPHQL_URL", "value": self.HASURA_GQL},
-                        {"name": "BOLT_HASURA_TOKEN", "value": workflow.auth_token},
-                        {"name": "PROMETHEUS_URL", "value": self.PROMETHEUS_URL},
-                        {"name": "MONITORING_INTERVAL", "value": str(self.MONITORING_INTERVAL)},
-                    ],
-                    "resources": self.CONTAINER_RESOURCES["master"],
-                },
-            }
-            templates.append(template_load_tests_metric_watcher)
+            if workflow.job_metric_watcher is not None:
+                template_load_tests_metric_watcher = {
+                    "name": "load-tests-metric-watcher",
+                    "nodeSelector": {"group": "load-tests-metric-watcher"},
+                    "container": {
+                        "image": "{{workflow.outputs.parameters.image}}",
+                        "command": ["python", "-m", "monitoring"],
+                        "env": [
+                            *self._map_envs(workflow.job_metric_watcher.env_vars),
+                            {"name": "EXECUTION_ID", "value": workflow.execution_id},
+                            {"name": "BOLT_GRAPHQL_URL", "value": self.HASURA_GQL},
+                            {"name": "BOLT_HASURA_TOKEN", "value": workflow.auth_token},
+                            {"name": "PROMETHEUS_URL", "value": self.PROMETHEUS_URL},
+                            {"name": "MONITORING_INTERVAL", "value": str(self.MONITORING_INTERVAL)},
+                        ],
+                        "resources": self.CONTAINER_RESOURCES["master"],
+                    },
+                }
+                templates.append(template_load_tests_metric_watcher)
 
             if workflow.job_load_tests.host is not None:
                 template_load_tests_slave["container"]["env"].append(

--- a/bolt-portal/src/pages/E2EScenarios/ScenarioDetails/ScenarioDetails.js
+++ b/bolt-portal/src/pages/E2EScenarios/ScenarioDetails/ScenarioDetails.js
@@ -58,7 +58,7 @@ const TestScenarioDetails = () => {
             variant="body1"
             className={classes.marginTop}
           >
-            {externalTestScenario.description || ''}
+            {externalTestScenario?.description || ''}
           </Typography>
         </Grid>
         {externalTestScenario?.test_runs?.length > 0 && (
@@ -84,7 +84,7 @@ const TestScenarioDetails = () => {
       </Grid>
       <div className={classes.marginTop}>
         <DataTable
-          data={externalTestScenario.test_runs}
+          data={externalTestScenario?.test_runs}
           isLoading={loading}
           rowKey={test_run => test_run.id}
         >

--- a/bolt-portal/src/pages/TestExecutions/MonitoringMetrics/MonitoringMetrics.js
+++ b/bolt-portal/src/pages/TestExecutions/MonitoringMetrics/MonitoringMetrics.js
@@ -28,6 +28,7 @@ import {
   SectionHeader,
   LoadingPlaceholder,
   ErrorPlaceholder,
+  NoDataPlaceholder,
 } from 'components/index'
 import { getUrl } from 'utils/router'
 import { Paper, Box } from '@material-ui/core'
@@ -64,7 +65,13 @@ const MonitoringMetrics = () => {
   )
 
   const formatTitle = title => title.replace(/_/g, ' ')
-
+  if (configuration_monitoring?.length === 0) {
+    return (
+      <Box p={3}>
+        <NoDataPlaceholder title="No metrics have been gathered..." />
+      </Box>
+    )
+  }
   if (loading || error) {
     return (
       <Box p={3}>
@@ -91,9 +98,10 @@ const MonitoringMetrics = () => {
       </SectionHeader>
 
       {configuration_monitoring &&
-        configuration_monitoring.map(query => (
+        configuration_monitoring.map((query, index) => (
           <ExpandablePanel
             defaultExpanded={true}
+            key={`${index}-expand-chart`}
             style={{ textTransform: 'capitalize' }}
             title={formatTitle(query.query)}
           >


### PR DESCRIPTION
- Updated the `_generate_steps_templates` method in `argo.py` to only append the `load-tests-metric-watcher` template if `workflow.job_metric_watcher` is not `None`. This prevents potential errors when `workflow.job_metric_watcher` is `None`.
- In `ScenarioDetails.js`, added optional chaining (`?.`) to `externalTestScenario` when accessing its `description` and `test_runs` properties. This ensures that an error will not be thrown if `externalTestScenario` is `undefined`.
- In `MonitoringMetrics.js`, added a check to return a `NoDataPlaceholder` component if `configuration_monitoring` is an empty array. This provides a better user experience when no metrics have been gathered.
- Also in `MonitoringMetrics.js`, added a `key` prop to the `ExpandablePanel` components being mapped from `configuration_monitoring`. This ensures that each `ExpandablePanel` has a unique key, as required by React.