### PR TITLE
Add errors column to test run view

### DIFF
--- a/bolt-portal/src/pages/E2EScenarios/ScenarioDetails/ScenarioDetails.js
+++ b/bolt-portal/src/pages/E2EScenarios/ScenarioDetails/ScenarioDetails.js
@@ -107,6 +107,12 @@ const TestScenarioDetails = () => {
             )}
             title="Failures"
           />
+          <DataTable.Column
+            render={test_run => (
+              <div className={classes.error}>{test_run.errors}</div>
+            )}
+            title="Errors"
+          />
           <DataTable.Column render={test_run => test_run.total} title="Total" />
           <DataTable.Column
             key="actions"

--- a/bolt-portal/src/pages/E2EScenarios/ScenarioDetails/ScenarioDetails.styles.js
+++ b/bolt-portal/src/pages/E2EScenarios/ScenarioDetails/ScenarioDetails.styles.js
@@ -31,6 +31,9 @@ export default makeStyles(({ spacing, palette }) => ({
   failure: {
     color: palette.text.error,
   },
+  error: {
+    color: palette.chart.color.errors[0],
+  },
   paper: {
     padding: spacing(4),
     width: '100%',

--- a/bolt-portal/src/pages/TestConfigurations/CreateOrEdit/components/ConfigurationForm/MonitoringFields/MonitoringFields.js
+++ b/bolt-portal/src/pages/TestConfigurations/CreateOrEdit/components/ConfigurationForm/MonitoringFields/MonitoringFields.js
@@ -36,10 +36,7 @@ import { Button } from 'components'
 function MonitoringFields({ isMonitoring, setIsMonitoring }) {
   const { mutators } = useForm()
 
-  const chartTypes = [
-    { value: 'default_chart', label: 'Default Chart' },
-    { value: 'second_chart', label: 'Second Chart' },
-  ]
+  const chartTypes = [{ value: 'line_chart', label: 'Line Chart' }]
   return (
     <>
       <FormControlLabel


### PR DESCRIPTION
- Added a new column to the `DataTable` in `ScenarioDetails.js` to display the number of errors in each test run. The errors are displayed in a div with a class that applies a specific color to the text.
- Updated the `ScenarioDetails.styles.js` to include a new style for the error text color.
- Simplified the `chartTypes` array in `MonitoringFields.js` to only include a single type of chart - 'Line Chart'. This change affects the options available for chart types in the monitoring fields of the test configuration form.