### PR TITLE
Add CPU warning

### DIFF
--- a/bolt-api/subsystems/hasura/metadata/databases/default/tables/public_execution.yaml
+++ b/bolt-api/subsystems/hasura/metadata/databases/default/tables/public_execution.yaml
@@ -106,6 +106,7 @@ select_permissions:
         - commit_hash
         - configuration_id
         - configuration_snapshot
+        - cpu_warning
         - created_by_id
         - end
         - end_locust
@@ -146,6 +147,7 @@ select_permissions:
         - commit_hash
         - configuration_id
         - configuration_snapshot
+        - cpu_warning
         - created_by_id
         - end
         - end_locust
@@ -180,6 +182,7 @@ select_permissions:
       columns:
         - configuration_id
         - configuration_snapshot
+        - cpu_warning
         - id
         - report
       filter:
@@ -193,13 +196,14 @@ select_permissions:
         - commit_hash
         - configuration_id
         - configuration_snapshot
+        - cpu_warning
         - created_by_id
         - end
         - end_locust
         - failed_requests
         - id
-        - report
         - passed_requests
+        - report
         - start
         - start_locust
         - status
@@ -233,6 +237,7 @@ select_permissions:
         - commit_hash
         - configuration_id
         - configuration_snapshot
+        - cpu_warning
         - created_by_id
         - end
         - end_locust
@@ -270,6 +275,7 @@ select_permissions:
         - commit_hash
         - configuration_id
         - configuration_snapshot
+        - cpu_warning
         - created_by_id
         - end
         - id
@@ -289,6 +295,7 @@ update_permissions:
   - role: reportgenerator
     permission:
       columns:
+        - cpu_warning
         - report
       filter:
         id:
@@ -297,6 +304,7 @@ update_permissions:
   - role: testrunner
     permission:
       columns:
+        - cpu_warning
         - end
         - end_locust
         - start

--- a/bolt-api/subsystems/hasura/migrations/default/1669047367727_add_cpu_warning/down.sql
+++ b/bolt-api/subsystems/hasura/migrations/default/1669047367727_add_cpu_warning/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."execution" add column "cpu_warning" boolean
+--  not null default 'false';

--- a/bolt-api/subsystems/hasura/migrations/default/1669047367727_add_cpu_warning/up.sql
+++ b/bolt-api/subsystems/hasura/migrations/default/1669047367727_add_cpu_warning/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."execution" add column "cpu_warning" boolean
+ not null default 'false';

--- a/bolt-portal/src/pages/TestExecutions/Details/Details.js
+++ b/bolt-portal/src/pages/TestExecutions/Details/Details.js
@@ -119,7 +119,7 @@ export function Details() {
           executionId={executionId}
           configurationId={configurationId}
         />
-        {execution.cpu_warning && <CPUWarningBadge/>}
+        {execution?.cpu_warning && <CPUWarningBadge/>}
         <ResultsPerTick classes={classes} execution={execution} />
         <ResultsPerEndpoint
           classes={classes}

--- a/bolt-portal/src/pages/TestExecutions/Details/Details.js
+++ b/bolt-portal/src/pages/TestExecutions/Details/Details.js
@@ -40,6 +40,7 @@ import { ExecutionActionsMenu, GenerateReportButton } from '../components'
 import { CompareResults, StatusGraph, ResultsPerEndpoint } from './components'
 import { SUBSCRIBE_TO_EXECUTION } from './graphql'
 import useStyles from './Details.styles'
+import CPUWarningBadge from "../components/CPUWarningBadge/CPUWarningBadge";
 
 export function Details() {
   const params = useParams()
@@ -118,6 +119,7 @@ export function Details() {
           executionId={executionId}
           configurationId={configurationId}
         />
+        {execution.cpu_warning && <CPUWarningBadge/>}
         <ResultsPerTick classes={classes} execution={execution} />
         <ResultsPerEndpoint
           classes={classes}

--- a/bolt-portal/src/pages/TestExecutions/Details/graphql.js
+++ b/bolt-portal/src/pages/TestExecutions/Details/graphql.js
@@ -45,6 +45,7 @@ export const SUBSCRIBE_TO_EXECUTION = gql`
       argo_namespace
       status
       report
+      cpu_warning
       configuration {
         id
         name

--- a/bolt-portal/src/pages/TestExecutions/EndpointDetails/EndpointDetails.js
+++ b/bolt-portal/src/pages/TestExecutions/EndpointDetails/EndpointDetails.js
@@ -59,7 +59,7 @@ function EndpointDetails() {
     <div>
       <SectionHeader title={`${endpoint.method} ${endpoint.name}`} marginBottom />
       <Grid container spacing={2}>
-        {endpoint.execution.cpu_warning && <CPUWarningBadge/>}
+        {endpoint?.execution?.cpu_warning && <CPUWarningBadge/>}
         <Results classes={classes} executionId={endpoint.execution_id} name={endpoint.name} />
         <Grid item xs={12} md={12}>
           <TimeDistribution classes={classes} endpointId={endpointId} />

--- a/bolt-portal/src/pages/TestExecutions/EndpointDetails/EndpointDetails.js
+++ b/bolt-portal/src/pages/TestExecutions/EndpointDetails/EndpointDetails.js
@@ -34,6 +34,7 @@ import {
 import { TimeDistribution, Results } from './components'
 import { GET_ENDPOINT } from './graphql'
 import useStyles from './EndpointDetails.styles'
+import CPUWarningBadge from "../components/CPUWarningBadge/CPUWarningBadge";
 
 function EndpointDetails() {
   const { endpointId } = useParams()
@@ -58,6 +59,7 @@ function EndpointDetails() {
     <div>
       <SectionHeader title={`${endpoint.method} ${endpoint.name}`} marginBottom />
       <Grid container spacing={2}>
+        {endpoint.execution.cpu_warning && <CPUWarningBadge/>}
         <Results classes={classes} executionId={endpoint.execution_id} name={endpoint.name} />
         <Grid item xs={12} md={12}>
           <TimeDistribution classes={classes} endpointId={endpointId} />

--- a/bolt-portal/src/pages/TestExecutions/EndpointDetails/graphql.js
+++ b/bolt-portal/src/pages/TestExecutions/EndpointDetails/graphql.js
@@ -34,6 +34,9 @@ export const GET_ENDPOINT = gql`
       method
       name
       execution_id
+      execution {
+        cpu_warning
+      }
     }
   }
 `

--- a/bolt-portal/src/pages/TestExecutions/components/CPUWarningBadge/CPUWarningBadge.js
+++ b/bolt-portal/src/pages/TestExecutions/components/CPUWarningBadge/CPUWarningBadge.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2022 Acaisoft
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import useStyles from "./CPUWarningBadge.style";
+import {Grid, Paper, Typography} from "@material-ui/core";
+import {WarningRounded} from '@material-ui/icons'
+import React from "react";
+
+
+export function CPUWarningBadge() {
+  const classes = useStyles()
+
+  return (
+    <Grid item xs={12}>
+      <Paper square className={classes.tile}>
+        <div className={classes.wrapper} data-testid="cpu-warning-badge">
+          <WarningRounded data-testid="test-run-status-icon" className={classes.icon} />
+          <Typography className={classes.text} variant="body1" displayBlock>
+            CPU usage has surpassed 90% on at least one of the worker nodes.
+            This may cause test results to be inaccurate.
+            Please consider lowering users/worker ratio.
+          </Typography>
+        </div>
+      </Paper>
+    </Grid>
+  )
+}
+
+export default CPUWarningBadge

--- a/bolt-portal/src/pages/TestExecutions/components/CPUWarningBadge/CPUWarningBadge.style.js
+++ b/bolt-portal/src/pages/TestExecutions/components/CPUWarningBadge/CPUWarningBadge.style.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2022 Acaisoft
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { makeStyles } from '@material-ui/core'
+
+export default makeStyles(({ palette, spacing }) => ({
+  icon: {
+    margin: spacing(1.2),
+    fontSize: '2.4rem',
+    color: palette.text.warning
+  },
+  text: {
+    margin: spacing(2),
+    fontSize: '0.9rem',
+    color: palette.text.primary,
+    whiteSpace: 'pre-wrap'
+  },
+  wrapper: {
+    padding: spacing(0.5, 1),
+    borderRadius: spacing(0.5),
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  title: {
+    padding: spacing(5),
+  }
+}))

--- a/bolt-portal/src/pages/TestsCompare/components/TestDetails/TestDetails.js
+++ b/bolt-portal/src/pages/TestsCompare/components/TestDetails/TestDetails.js
@@ -75,7 +75,7 @@ function TestDetails({ titleStart, execution, className }) {
         </ExpandablePanel>
       </div>
       <Grid container spacing={2}>
-        {execution.cpu_warning && <CPUWarningBadge/>}
+        {execution?.cpu_warning && <CPUWarningBadge/>}
         <ResultsPerTick
           classes={classes}
           execution={execution}

--- a/bolt-portal/src/pages/TestsCompare/components/TestDetails/TestDetails.js
+++ b/bolt-portal/src/pages/TestsCompare/components/TestDetails/TestDetails.js
@@ -34,6 +34,7 @@ import {
 } from 'components'
 import CompareEndpointResults from './CompareEndpointResults'
 import useStyles from './TestDetails.styles'
+import CPUWarningBadge from "../../../TestExecutions/components/CPUWarningBadge/CPUWarningBadge";
 
 const gridProps = {
   iconContainerProps: { xs: 12, md: 12, xl: 1 },
@@ -74,6 +75,7 @@ function TestDetails({ titleStart, execution, className }) {
         </ExpandablePanel>
       </div>
       <Grid container spacing={2}>
+        {execution.cpu_warning && <CPUWarningBadge/>}
         <ResultsPerTick
           classes={classes}
           execution={execution}

--- a/bolt-portal/src/pages/TestsCompare/graphql.js
+++ b/bolt-portal/src/pages/TestsCompare/graphql.js
@@ -43,6 +43,7 @@ export const SUBSCRIBE_TO_EXECUTION_DETAILS = gql`
       end_locust
       argo_name
       status
+      cpu_warning
       configuration {
         id
         name


### PR DESCRIPTION
- A new column `cpu_warning` has been added to the `execution` table in the database. This column is a boolean type and is not nullable, with a default value of 'false'. This change is reflected in the Hasura metadata and migrations.
- The `cpu_warning` field has been added to the GraphQL queries in the `TestExecutions` and `TestsCompare` pages.
- A new component `CPUWarningBadge` has been created. This component displays a warning message when the CPU usage surpasses 90% on at least one of the worker nodes, indicating that the test results may be inaccurate and suggesting to consider lowering the users/worker ratio.
- The `CPUWarningBadge` component has been added to the `TestExecutions` and `TestsCompare` pages. It is displayed when the `cpu_warning` field of the execution is true.
- The `CPUWarningBadge` component includes its own styling file `CPUWarningBadge.style.js`, which defines the styles for the component.
- The `CPUWarningBadge` component and its styles are licensed under the MIT license, as indicated by the copyright notice in the files.